### PR TITLE
removed width: 100% for under construction splash screen

### DIFF
--- a/components/underConstruction.module.scss
+++ b/components/underConstruction.module.scss
@@ -19,7 +19,6 @@
   max-width: 460px;
   margin: 0 auto;
   padding: map-get($spacing-sizes, "1") map-get($spacing-sizes, "2");
-  width: 100%;
   span,
   h2 {
     align-self: center;


### PR DESCRIPTION
Title says it all, container was wider than screen on some very small mobile screens.